### PR TITLE
Add version specific stats

### DIFF
--- a/packageinfo.html
+++ b/packageinfo.html
@@ -35,16 +35,15 @@
     <input type="text" id="packagename" class="form-control" style="text-align: center"/>
     <button id="submit-button" type="submit" class="btn btn-primary" pys-onClick="plot_package_info">Query</button>
     <div id="charts"></div>
-    <py-script src="pyscript/callbacks.py"></py-script>
     <div id="versionSelector" style="visibility: hidden">
-        Select a version to analyze further:
-        <button class = "btn btn-secondary dropdown-toggle" type="button" id="versionSelectorDropDownBtn" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Select version
-        </button>
-        <div class="dropdown-menu" aria-labelledby="dropdownMenuButton" id="versionDropDownMenu">
-        </div>
+        <select class="form-select" id="versionDropDownMenu" aria-label="Select a version">
+            <option selected>Select a version to analyze further:</option>
+        </select>
+        <button id="version-submit-button" type="submit" class="btn btn-primary" pys-onClick="plot_version_package_info">Query</button>
+        <div id="version_charts"></div>
     </div>
     <template id="versionDropDownTemplate">
-        <a class="dropdown-item" href="#"></a>
+        <option>Dummy option</option>
     </template>
+    <py-script src="pyscript/callbacks.py"></py-script>
 </body>

--- a/pyscript/stats.py
+++ b/pyscript/stats.py
@@ -5,6 +5,7 @@ from bokeh.transform import cumsum
 from pandas import DataFrame
 from util import calculate_pie_chart_angle
 
+category20c = Category20c[20]
 
 def plot_top_downloaded_files(data: DataFrame, packagename: str, n: int) -> Figure:
     source = ColumnDataSource(data.head(n)[["file", "download_counts"]])
@@ -23,9 +24,8 @@ def plot_wheel_coverage(data: DataFrame, packagename: str) -> Figure:
     ftype_counts = grouped_stats["download_counts"].sum().reset_index()
     # Manually calculate pie chart angles since bokeh doesn't do that
     # for us
-    # ftype_counts["angle"] = ftype_counts["download_counts"]/ftype_counts["download_counts"].sum() * 2 * pi
     ftype_counts = calculate_pie_chart_angle(ftype_counts, "download_counts")
-    ftype_counts["color"] = Category20c[len(ftype_counts)]
+    ftype_counts["color"] = category20c[len(ftype_counts)]
     p = figure(title="Wheel coverage", tooltips="@ftype: @download_counts")
     p.wedge(
         x=0,
@@ -65,7 +65,7 @@ def plot_versions(data: DataFrame, packagename: str, n: int) -> Figure:
     topn_versions["other"] = grouped_version_stats[n:].sum()
     topn_versions = topn_versions.reset_index()
     topn_versions = calculate_pie_chart_angle(topn_versions, "download_counts")
-    topn_versions["color"] = Category20c[len(topn_versions)]
+    topn_versions["color"] = category20c[len(topn_versions)]
     p = figure(
         title=f"Top {n} downloaded versions for package {packagename}",
         tooltips="@version: @download_counts",


### PR DESCRIPTION
- Use ``<select>`` instead of bootstraps dropdown
- Add wheel coverage, top downloaded_files, and platforms version specific stats